### PR TITLE
Add repo field so npm stops complaining

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "directories": {
     "test": "test"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btford/weasel-words.git"
+  },
   "scripts": {
     "test": "./node_modules/.bin/jasmine-node test"
   },


### PR DESCRIPTION
Add repo field so when you install write-good you don't get warnings from npm.